### PR TITLE
Ensure nagios checks start with 'check_'

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -37,7 +37,7 @@ define service {
     servicegroups                   %(servicegroups)s
 }
 """
-        check_filename = "/etc/nagios/nrpe.d/%s.cfg" % (name)
+        check_filename = "/etc/nagios/nrpe.d/check_%s.cfg" % (name)
         with open(check_filename, "w") as fh:
             fh.write(check_tmpl % {
                 'check_args': ' '.join(args),


### PR DESCRIPTION
This works around a mojo bug (https://bugs.launchpad.net/bugs/1694890), but would be good to fix here as well.