### PR TITLE
Explain that a nagios-nrpe-server restart may be required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ def setup_nagios(nagios):
         unit=unit_name,
     )
 ```
+If your `nagios.add_check` defines a custom plugin, you will also need to restart the `nagios-nrpe-server`. 
 
 Consult the nagios documentation for more information on [how to write your own
 plugins](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/4/en/pluginapi.html)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ def setup_nagios(nagios):
         unit=unit_name,
     )
 ```
-If your `nagios.add_check` defines a custom plugin, you will also need to restart the `nagios-nrpe-server`. 
+If your `nagios.add_check` defines a custom plugin, you will also need to restart the `nagios-nrpe-server` service. 
 
 Consult the nagios documentation for more information on [how to write your own
 plugins](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/4/en/pluginapi.html)


### PR DESCRIPTION
Update the README to make it clear that if nagios.add_check() is called to define a custom plugin, a restart of nagios-nrpe-server is also required, otherwise nagios will not recognise the new nrpe command.