### PR TITLE
Leave .available flag set w/relation data.

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -89,4 +89,3 @@ define service {
             'timestamp': datetime.datetime.now().isoformat(),
         }
         self.set_remote(**relation_info)
-        self.remove_state('{relation_name}.available')


### PR DESCRIPTION
This changes behavior slightly and will require users of this interface
to use their own flags to determine whether they've responded to the
relation join/depart events properly. However it is necessary so that
config changes can access the relation data and reconfigure nagios
accordingly.

Fixes #12 